### PR TITLE
Fix shrine of blood scaling

### DIFF
--- a/ShareSuite/Hooks.cs
+++ b/ShareSuite/Hooks.cs
@@ -298,12 +298,13 @@ namespace ShareSuite
 
                             var purchaseInteraction = self.GetComponent<PurchaseInteraction>();
                             var shrineBloodBehavior = self.GetComponent<ShrineBloodBehavior>();
-                            var amount = (uint) (teamMaxHealth * purchaseInteraction.cost / 100.0 * shrineBloodBehavior.goldToPaidHpRatio);
+                            var amount = (uint) (teamMaxHealth * purchaseInteraction.cost / 100.0 *
+                                                 shrineBloodBehavior.goldToPaidHpRatio);
                             
                             if (ShareSuite.MoneyScalarEnabled.Value) amount *= (uint) ShareSuite.MoneyScalar.Value;
                             var purchaseDiff =
                                 amount - (uint) ((double) characterBody.maxHealth * purchaseInteraction.cost / 100.0 *
-                                                 0.5f);
+                                                 shrineBloodBehavior.goldToPaidHpRatio);
 
                             foreach (var playerCharacterMasterController in PlayerCharacterMasterController.instances)
                             {

--- a/ShareSuite/Hooks.cs
+++ b/ShareSuite/Hooks.cs
@@ -297,10 +297,10 @@ namespace ShareSuite
                             }
 
                             var purchaseInteraction = self.GetComponent<PurchaseInteraction>();
-                            var amount = (uint) (teamMaxHealth * purchaseInteraction.cost / 100.0 * 0.5f);
+                            var shrineBloodBehavior = self.GetComponent<ShrineBloodBehavior>();
+                            var amount = (uint) (teamMaxHealth * purchaseInteraction.cost / 100.0 * shrineBloodBehavior.goldToPaidHpRatio);
                             
                             if (ShareSuite.MoneyScalarEnabled.Value) amount *= (uint) ShareSuite.MoneyScalar.Value;
-
                             var purchaseDiff =
                                 amount - (uint) ((double) characterBody.maxHealth * purchaseInteraction.cost / 100.0 *
                                                  0.5f);


### PR DESCRIPTION
This pulls in the existing instance of the shrine of blood on health cost interactions to grab its instantiated gold to hp ratio instead of overriding its value with the default of 0.5. From my tests, it appeared to be working, but it could probably use some extra tests.