### PR TITLE
1.10.2-1.10.4

### DIFF
--- a/ShareSuite/Hooks.cs
+++ b/ShareSuite/Hooks.cs
@@ -146,7 +146,7 @@ namespace ShareSuite
                 orig(self);
                 if (!ShareSuite.ModIsEnabled.Value) return;
 
-                var defaultCredit = self.GetFieldValue<int>("interactableCredit");
+                // var defaultCredit = self.GetFieldValue<int>("interactableCredit");
                 // Set interactables budget to 200 * config player count (normal calculation)
                 if (ShareSuite.OverridePlayerScalingEnabled.Value)
                     self.SetFieldValue("interactableCredit", 200 * ShareSuite.InteractablesCredit.Value);
@@ -255,7 +255,7 @@ namespace ShareSuite
                     orig(self, activator);
                     return;
                 }
-
+                
                 // Return if you can't afford the item
                 if (!self.CanBeAffordedByInteractor(activator)) return;
 
@@ -284,6 +284,7 @@ namespace ShareSuite
 
                         case CostTypeIndex.PercentHealth:
                         {
+                            Debug.Log("interaction began");
                             orig(self, activator);
                             var teamMaxHealth = 0;
                             foreach (var playerCharacterMasterController in PlayerCharacterMasterController.instances)
@@ -299,12 +300,14 @@ namespace ShareSuite
                             var shrineBloodBehavior = self.GetComponent<ShrineBloodBehavior>();
                             var amount = (uint) (teamMaxHealth * purchaseInteraction.cost / 100.0 *
                                                  shrineBloodBehavior.goldToPaidHpRatio);
+                            Debug.Log(amount);
 
                             if (ShareSuite.MoneyScalarEnabled.Value) amount *= (uint) ShareSuite.MoneyScalar.Value;
                             var purchaseDiff =
                                 amount - (uint) ((double) characterBody.maxHealth * purchaseInteraction.cost / 100.0 *
                                                  shrineBloodBehavior.goldToPaidHpRatio);
 
+                            Debug.Log(purchaseDiff);
                             foreach (var playerCharacterMasterController in PlayerCharacterMasterController.instances)
                             {
                                 if (!playerCharacterMasterController.master.alive) continue;
@@ -327,7 +330,7 @@ namespace ShareSuite
                 }
 
                 var shop = self.GetComponent<ShopTerminalBehavior>();
-
+                
                 // If the cost type is an item, give the user the item directly and send the pickup message
                 if (self.costType == CostTypeIndex.WhiteItem
                     || self.costType == CostTypeIndex.GreenItem
@@ -422,11 +425,6 @@ namespace ShareSuite
                    || index == ItemIndex.SprintWisp
                    || index == ItemIndex.TitanGoldDuringTP
                    || index == ItemIndex.BeetleGland;
-        }
-
-        public static bool IsQueensGland(ItemIndex index)
-        {
-            return index == ItemIndex.BeetleGland;
         }
     }
 }

--- a/ShareSuite/ShareSuite.cs
+++ b/ShareSuite/ShareSuite.cs
@@ -15,30 +15,18 @@ namespace ShareSuite
 {
     [BepInDependency("com.frogtown.shared", BepInDependency.DependencyFlags.SoftDependency)]
     [BepInDependency("com.bepis.r2api")]
-    [BepInPlugin("com.funkfrog_sipondo.sharesuite", "ShareSuite", "1.10.1")]
+    [BepInPlugin("com.funkfrog_sipondo.sharesuite", "ShareSuite", "1.10.4")]
     public class ShareSuite : BaseUnityPlugin
     {
-        public static ConfigWrapper<bool> ModIsEnabled;
-        public static ConfigWrapper<bool> MoneyIsShared;
-        public static ConfigWrapper<bool> WhiteItemsShared;
-        public static ConfigWrapper<bool> GreenItemsShared;
-        public static ConfigWrapper<bool> RedItemsShared;
-        public static ConfigWrapper<bool> EquipmentShared;
-        public static ConfigWrapper<bool> LunarItemsShared;
-        public static ConfigWrapper<bool> BossItemsShared;
-        public static ConfigWrapper<bool> PrinterCauldronFixEnabled;
-        public static ConfigWrapper<bool> DeadPlayersGetItems;
-        public static ConfigWrapper<bool> OverridePlayerScalingEnabled;
-        public static ConfigWrapper<int> InteractablesCredit;
-        public static ConfigWrapper<bool> OverrideBossLootScalingEnabled;
-        public static ConfigWrapper<int> BossLootCredit;
-        public static ConfigWrapper<bool> MoneyScalarEnabled;
-        public static ConfigWrapper<int> MoneyScalar;
-        public static ConfigWrapper<string> ItemBlacklist;
-        public static ConfigWrapper<string> EquipmentBlacklist;
+        public static ConfigWrapper<bool> ModIsEnabled, MoneyIsShared, WhiteItemsShared, GreenItemsShared, 
+            RedItemsShared, EquipmentShared, LunarItemsShared, BossItemsShared, PrinterCauldronFixEnabled, 
+            DeadPlayersGetItems, OverridePlayerScalingEnabled, OverrideBossLootScalingEnabled, MoneyScalarEnabled;
+        public static ConfigWrapper<int> InteractablesCredit, BossLootCredit, MoneyScalar;
+        public static ConfigWrapper<string> ItemBlacklist, EquipmentBlacklist;
 
         public static HashSet<int> GetItemBlackList()
         {
+            
             var blacklist = new HashSet<int>();
             var rawPieces = ItemBlacklist.Value.Split(',');
             foreach (var piece in rawPieces)
@@ -68,6 +56,7 @@ namespace ShareSuite
             var highestBal = (uint) HighestBalance();
             foreach (var playerCharacterMasterController in PlayerCharacterMasterController.instances)
             {
+                if (!playerCharacterMasterController.master.alive) continue;
                 if (playerCharacterMasterController.master.money != highestBal)
                 {
                     playerCharacterMasterController.master.money = highestBal;
@@ -80,6 +69,7 @@ namespace ShareSuite
             var teamMaxMoney = 0;
             foreach (var playerCharacterMasterController in PlayerCharacterMasterController.instances)
             {
+                if (!playerCharacterMasterController.master.alive) continue;
                 var charBalance = playerCharacterMasterController.master.money;
                 if (charBalance > teamMaxMoney)
                 {

--- a/ShareSuite/ShareSuite.csproj
+++ b/ShareSuite/ShareSuite.csproj
@@ -20,7 +20,7 @@
       <HintPath>..\libs\BepInEx.dll</HintPath>
     </Reference>
     <Reference Include="MMHOOK_Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\SteamApps\common\Risk of Rain 2\BepInEx\plugins\tristanmcpherson-R2API\R2API\MMHOOK_Assembly-CSharp.dll</HintPath>
+      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\SteamApps\common\Risk of Rain 2\BepInEx\plugins\R2API\MMHOOK_Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cecil">
       <HintPath>..\libs\Mono.Cecil.dll</HintPath>
@@ -28,8 +28,8 @@
     <Reference Include="MonoMod.Utils">
       <HintPath>..\libs\MonoMod.Utils.dll</HintPath>
     </Reference>
-    <Reference Include="R2API, Version=2.1.15.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\SteamApps\common\Risk of Rain 2\BepInEx\plugins\tristanmcpherson-R2API\R2API\R2API.dll</HintPath>
+    <Reference Include="R2API, Version=2.1.11.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\SteamApps\common\Risk of Rain 2\BepInEx\plugins\R2API\R2API.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine">
       <HintPath>..\libs\UnityEngine.dll</HintPath>


### PR DESCRIPTION
1.10.4 - Fixed a similar bug as 1.10.3; Money will no longer stay above the highest amount of money a dead player has. (Thanks to Elysium for finding this!) Also updated R2Api dependency to 2.1.16.

1.10.3 - Moved Discord link below Features list. Fixed incorrectly formatted horizontal rule. Fixed bug with Shared money keeping everyone at the same balance if a teammate died. What should I work on next? Vote here!

1.10.2 - Added Discord link to the README. Mod file is unchanged.