### PR TITLE
Added option to randomize shared items

### DIFF
--- a/ShareSuite/ItemSharingHooks.cs
+++ b/ShareSuite/ItemSharingHooks.cs
@@ -182,22 +182,32 @@ namespace ShareSuite
         private static bool IsValidItemPickup(PickupIndex pickup)
         {
             var pickupdef = PickupCatalog.GetPickupDef(pickup);
-            var itemdef = ItemCatalog.GetItemDef(pickupdef.itemIndex);
-            switch (itemdef.tier)
+            if (pickupdef.itemIndex != ItemIndex.None)
             {
-                case ItemTier.Tier1:
-                    return ShareSuite.WhiteItemsShared.Value;
-                case ItemTier.Tier2:
-                    return ShareSuite.GreenItemsShared.Value;
-                case ItemTier.Tier3:
-                    return ShareSuite.RedItemsShared.Value;
-                case ItemTier.Lunar:
-                    return ShareSuite.LunarItemsShared.Value;
-                case ItemTier.Boss:
-                    return ShareSuite.BossItemsShared.Value;
-                default:
-                    return false;
+                var itemdef = ItemCatalog.GetItemDef(pickupdef.itemIndex);
+                switch (itemdef.tier)
+                {
+                    case ItemTier.Tier1:
+                        return ShareSuite.WhiteItemsShared.Value;
+                    case ItemTier.Tier2:
+                        return ShareSuite.GreenItemsShared.Value;
+                    case ItemTier.Tier3:
+                        return ShareSuite.RedItemsShared.Value;
+                    case ItemTier.Lunar:
+                        return ShareSuite.LunarItemsShared.Value;
+                    case ItemTier.Boss:
+                        return ShareSuite.BossItemsShared.Value;
+                    default:
+                        return false;
+                }
             }
+            else if (pickupdef.equipmentIndex != EquipmentIndex.None)
+            {
+                // var equipdef = EquipmentCatalog.GetEquipmentDef(pickupdef.equipmentIndex);
+                // Optional further checks ...
+                return false;
+            }
+            return false;
         }
 
         private static ItemIndex GetRandomItemOfTier(ItemTier tier, ItemIndex orDefault)

--- a/ShareSuite/ShareSuite.cs
+++ b/ShareSuite/ShareSuite.cs
@@ -221,7 +221,7 @@ namespace ShareSuite
             RandomizeSharedPickups = Config.Wrap(
                 "Settings",
                 "RandomizeSharedPickups",
-                "When enabled each player (except the player who picked up the item) will get a radomized item of the same rarity.",
+                "When enabled each player (except the player who picked up the item) will get a randomized item of the same rarity.",
                 false);
         }
 

--- a/ShareSuite/ShareSuite.cs
+++ b/ShareSuite/ShareSuite.cs
@@ -31,7 +31,8 @@ namespace ShareSuite
             DeadPlayersGetItems,
             OverridePlayerScalingEnabled,
             OverrideBossLootScalingEnabled,
-            MoneyScalarEnabled;
+            MoneyScalarEnabled,
+            RandomizeSharedPickups;
 
         public static ConfigWrapper<int> BossLootCredit;
         public static ConfigWrapper<double> InteractablesCredit, MoneyScalar;
@@ -216,6 +217,12 @@ namespace ShareSuite
                 "EquipmentBlacklist",
                 "Equipment (by index) that you do not want to share, comma separated. Please find the indices at: https://github.com/risk-of-thunder/R2Wiki/wiki/Item-&-Equipment-IDs-and-Names",
                 "");
+
+            RandomizeSharedPickups = Config.Wrap(
+                "Settings",
+                "RandomizeSharedPickups",
+                "When enabled each player (except the player who picked up the item) will get a radomized item of the same rarity.",
+                false);
         }
 
         private static bool TryParseIntoConfig<T>(string rawValue, ConfigWrapper<T> wrapper)
@@ -412,6 +419,17 @@ namespace ShareSuite
                 Debug.Log("Invalid arguments.");
             else
                 Debug.Log($"Boss loot scaling disable set to {DeadPlayersGetItems.Value}.");
+        }
+
+        // InteractablesCredit
+        [ConCommand(commandName = "ss_RandomizeSharedPickups", flags = ConVarFlags.None,
+            helpText = "Randomizes pickups per player.")]
+        private static void CcRandomizeSharedPickups(ConCommandArgs args)
+        {
+            if (args.Count != 1 || !TryParseIntoConfig(args[0], RandomizeSharedPickups))
+                Debug.Log("Invalid arguments.");
+            else
+                Debug.Log($"Randomize pickups per player set to {RandomizeSharedPickups.Value}.");
         }
 
         #endregion CommandParser

--- a/ShareSuite/ShareSuite.cs
+++ b/ShareSuite/ShareSuite.cs
@@ -392,9 +392,7 @@ namespace ShareSuite
             if (args.Count != 1 || !TryParseIntoConfig(args[0], OverrideBossLootScalingEnabled))
                 Debug.Log("Invalid arguments.");
             else
-            {
                 Debug.Log($"Boss loot scaling disable set to {OverrideBossLootScalingEnabled.Value}.");
-            }
         }
 
         // BossLootCredit
@@ -405,20 +403,18 @@ namespace ShareSuite
             if (args.Count != 1 || !TryParseIntoConfig(args[0], BossLootCredit))
                 Debug.Log("Invalid arguments.");
             else
-            {
                 Debug.Log($"Boss loot credit set to {BossLootCredit.Value}.");
-            }
         }
 
         // DeadPlayersGetItems
         [ConCommand(commandName = "ss_DeadPlayersGetItems", flags = ConVarFlags.None,
-            helpText = "Modifies whether boss loot should scale based on player count.")]
+            helpText = "Modifies whether items are shared to dead players.")]
         private static void CcDeadPlayersGetItems(ConCommandArgs args)
         {
             if (args.Count != 1 || !TryParseIntoConfig(args[0], DeadPlayersGetItems))
                 Debug.Log("Invalid arguments.");
             else
-                Debug.Log($"Boss loot scaling disable set to {DeadPlayersGetItems.Value}.");
+                Debug.Log($"Dead player getting shared items set to {DeadPlayersGetItems.Value}");
         }
 
         // InteractablesCredit


### PR DESCRIPTION
This more or less implements #62; we wanted an option like this too so I went ahead to quickly implemented it.

I tried to follow your coding conventions as good as I can. If you think anything feels out of place or wrong, feel free to change it or contact me back (here or discord Splamy#0729)

The only thing I want to annotate maybe is this:
https://github.com/FunkFrog/RoR2SharedItems/blob/382d2a32dd164df4e89ef633d7ba3c4b87bb9c32/ShareSuite/ItemSharingHooks.cs#L139-L140
If I understand the BlackList correctly it is there to prevent overpowered/global/team items to be given multiple times since the effects are added together in the world anyway. I skip this check in the randomized version since everybody gets an random item anyway. Theoretically such items can still be given multiple times with a single pickup but that would be the same as randomly getting it twice.