### PR TITLE
Fixed crash with blacklisted boss items

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*.cs]
+end_of_line = lf
+
+indent_style = space
+indent_size = 4
+
+csharp_space_after_cast = true

--- a/ShareSuite/BlackList.cs
+++ b/ShareSuite/BlackList.cs
@@ -1,0 +1,102 @@
+﻿using RoR2;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ShareSuite
+{
+    public static class BlackList
+    {
+        private static ItemMask _cachedAvailableItems;
+
+        public static ItemMask _items = ItemMask.none;
+        public static EquipmentMask _equipment = EquipmentMask.none;
+        private static readonly List<PickupIndex> _availableTier1DropList = new List<PickupIndex>();
+        private static readonly List<PickupIndex> _availableTier2DropList = new List<PickupIndex>();
+        private static readonly List<PickupIndex> _availableTier3DropList = new List<PickupIndex>();
+        private static readonly List<PickupIndex> _availableLunarDropList = new List<PickupIndex>();
+        private static readonly List<PickupIndex> _availableBossDropList = new List<PickupIndex>();
+
+        public static List<PickupIndex> AvailableTier1DropList => Get(_availableTier1DropList);
+        public static List<PickupIndex> AvailableTier2DropList => Get(_availableTier2DropList);
+        public static List<PickupIndex> AvailableTier3DropList => Get(_availableTier3DropList);
+        public static List<PickupIndex> AvailableLunarDropList => Get(_availableLunarDropList);
+        public static List<PickupIndex> AvailableBossDropList => Get(_availableBossDropList);
+
+        private static void LoadBlackListItems()
+        {
+            _items = ItemMask.none;
+            foreach (var piece in ShareSuite.ItemBlacklist.Value.Split(','))
+                if (int.TryParse(piece.Trim(), out var itemIndex))
+                    _items.AddItem((ItemIndex) itemIndex);
+        }
+
+        private static void LoadBlackListEquipment()
+        {
+            _equipment = EquipmentMask.none;
+            foreach (var piece in ShareSuite.EquipmentBlacklist.Value.Split(','))
+                if (int.TryParse(piece.Trim(), out var equipmentIndex))
+                    _equipment.AddEquipment((EquipmentIndex) equipmentIndex);
+        }
+
+        public static bool HasItem(ItemIndex itemIndex)
+        {
+            ValidateItemCache();
+            return _items.HasItem(itemIndex);
+        }
+
+        public static bool HasEquipment(EquipmentIndex equipmentIndex)
+        {
+            ValidateItemCache();
+            return _equipment.HasEquipment(equipmentIndex);
+        }
+
+        public static void Recalculate() => _cachedAvailableItems = ItemMask.none;
+
+        private static void ValidateItemCache()
+        {
+            if (Run.instance == null)
+            {
+                Recalculate();
+                return;
+            }
+
+            if (ItemMaskEquals(_cachedAvailableItems, Run.instance.availableItems))
+                return;
+
+            _cachedAvailableItems = Run.instance.availableItems;
+
+            // Available items have changed; recalculate available items minus blacklists
+
+            LoadBlackListItems();
+            LoadBlackListEquipment();
+
+            var pairs = new[] {
+                (_availableTier1DropList, Run.instance.availableTier1DropList),
+                (_availableTier2DropList, Run.instance.availableTier2DropList),
+                (_availableTier3DropList, Run.instance.availableTier3DropList),
+                (_availableLunarDropList, Run.instance.availableLunarDropList),
+                (_availableBossDropList , Run.instance.availableBossDropList ),
+            };
+            foreach (var (availMinusBlack, source) in pairs)
+            {
+                availMinusBlack.Clear();
+                availMinusBlack.AddRange(source.Where(pickupIndex =>
+                {
+                    var pickupDef = PickupCatalog.GetPickupDef(pickupIndex);
+                    return !_items.HasItem(pickupDef.itemIndex);
+                }));
+            }
+        }
+
+        // Util
+
+        private static List<PickupIndex> Get(List<PickupIndex> list)
+        {
+            ValidateItemCache();
+            return list;
+        }
+
+        private static bool ItemMaskEquals(ItemMask first, ItemMask second)
+            => first.a == second.a && first.b == second.b;
+    }
+}

--- a/ShareSuite/ChatHandler.cs
+++ b/ShareSuite/ChatHandler.cs
@@ -33,7 +33,7 @@ namespace ShareSuite
             var pickupName = Language.GetString(pickupDef.nameToken);
             var playerColor = GetPlayerColor(player.playerCharacterMasterController);
 
-            if (ShareSuite.GetItemBlackList().Contains((int) pickupDef.itemIndex)
+            if (BlackList.HasItem(pickupDef.itemIndex)
                 || !ItemSharingHooks.IsValidItemPickup(pickupDef.pickupIndex))
             {
                 var singlePickupMessage =

--- a/ShareSuite/EquipmentSharingHooks.cs
+++ b/ShareSuite/EquipmentSharingHooks.cs
@@ -21,7 +21,7 @@ namespace ShareSuite
 
             var equip = PickupCatalog.GetPickupDef(self.pickupIndex).equipmentIndex;
 
-            if (!ShareSuite.GetEquipmentBlackList().Contains((int)equip)
+            if (!BlackList.HasEquipment(equip)
                 && NetworkServer.active
                 && IsValidEquipmentPickup(self.pickupIndex)
                 && GeneralHooks.IsMultiplayer())
@@ -41,7 +41,7 @@ namespace ShareSuite
 
             #endregion
         }
-        
+
         private static void SetEquipmentIndex(Inventory self, EquipmentIndex newEquipmentIndex, uint slot)
         {
             if (!NetworkServer.active) return;

--- a/ShareSuite/ShareSuite.csproj
+++ b/ShareSuite/ShareSuite.csproj
@@ -24,10 +24,10 @@
       <HintPath>..\libs\Mono.Cecil.dll</HintPath>
       <Private>false</Private>
     </Reference>
-    <Reference Include="MonoMod.RuntimeDetour, Version=19.11.5.1, Culture=neutral, PublicKeyToken=null">
+    <Reference Include="MonoMod.RuntimeDetour">
       <HintPath>..\libs\MonoMod.RuntimeDetour.dll</HintPath>
     </Reference>
-    <Reference Include="MonoMod.Utils, Version=19.11.5.1, Culture=neutral, PublicKeyToken=null">
+    <Reference Include="MonoMod.Utils">
       <HintPath>..\libs\MonoMod.Utils.dll</HintPath>
     </Reference>
     <Reference Include="R2API, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null">


### PR DESCRIPTION
## Issue
The game will freeze with randomize shared items enabled when picking up a boss items wich is also on the blacklist.

## Cause
1. ShareSuite will random an item for each player except the one who picked it up
https://github.com/FunkFrog/RoR2SharedItems/blob/5b7bced132efeccd7b147c6fb3b7b5ddd5041fb0/ShareSuite/ItemSharingHooks.cs#L64
2. Then check if it is blacklisted, and rerandom it
https://github.com/FunkFrog/RoR2SharedItems/blob/5b7bced132efeccd7b147c6fb3b7b5ddd5041fb0/ShareSuite/ItemSharingHooks.cs#L67
3. But since `GetRandomItemOfTier` always returns the same boss item, the `while` loop will never exit
https://github.com/FunkFrog/RoR2SharedItems/blob/5b7bced132efeccd7b147c6fb3b7b5ddd5041fb0/ShareSuite/ItemSharingHooks.cs#L280-L281

## Fix
I created a own `BlackList` class which manages blacklisted items and also offers available item lists which are already pre-filtered with the blacklist.
A random pick from one of these lists is now always guarateed to not have a blacklisted item, and if the available list is empty instead no item will be shared.

This change should also improve performance when picking up a lot of items since there are no more allocations nor loops at runtime.
The precalculated lists will be refreshed whenever either the config changes or new items get unlocked.

## Other stuff
- I've added a `.editorconfig` so my VS doesn't go nuts and apply my formatting preferences when i autoformat the code.
- Is there any reason the two references to `MonoMod.RuntimeDetour` and `MonoMod.Utils` (and some others, but they worked somehow) in the `ShareSuite.csproj` are fully specified? I couldn't get my VS to find/accept these libraries until I removed the full specification. If you need them, I can add them back.
- If there's anything you're unhappy about or any newly introduced bugs let me know here or on discord