### PR TITLE
Fix incompatibility with AutoItemPickup

### DIFF
--- a/ShareSuite/ItemSharingHooks.cs
+++ b/ShareSuite/ItemSharingHooks.cs
@@ -42,6 +42,9 @@ namespace ShareSuite
             var itemDef = ItemCatalog.GetItemDef(item.itemIndex);
             var randomizedPlayerDict = new Dictionary<CharacterMaster, PickupDef>();
 
+            // If the player is dead, they might not have a body. The game uses inventory.GetComponent, avoiding the issue entirely.
+            var master = body?.master ?? inventory?.GetComponent<CharacterMaster>();
+
             if ((ShareSuite.RandomizeSharedPickups.Value ||
                  !Blacklist.HasItem(item.itemIndex))
                 && NetworkServer.active
@@ -50,7 +53,7 @@ namespace ShareSuite
             {
                 if (ShareSuite.RandomizeSharedPickups.Value)
                 {
-                    randomizedPlayerDict.Add(body.master, item);
+                    randomizedPlayerDict.Add(master, item);
                 }
 
                 foreach (var player in PlayerCharacterMasterController.instances.Select(p => p.master))
@@ -90,13 +93,13 @@ namespace ShareSuite
 
                 if (ShareSuite.RandomizeSharedPickups.Value)
                 {
-                    ChatHandler.SendRichRandomizedPickupMessage(body.master, item, randomizedPlayerDict);
+                    ChatHandler.SendRichRandomizedPickupMessage(master, item, randomizedPlayerDict);
                     orig(self, body, inventory);
                     return;
                 }
             }
 
-            ChatHandler.SendRichPickupMessage(body.master, item);
+            ChatHandler.SendRichPickupMessage(master, item);
             orig(self, body, inventory);
         }
 


### PR DESCRIPTION
My mod, [AutoItemPickup](https://thunderstore.io/package/KubeRoot/AutoItemPickup/), calls `GenericPickupController.GrantItem(CharacterBody body, Inventory inventory)` in order to distribute an item to a player. It also always passes `null` for the `body` argument, in part because the items may be distributed to dead, body-less players.

This does not cause an issue with the base game, since the argument is completely unused. In ShareSuite, however, `body` is used to get the `CharacterBody.master` field without a null check. This causes an incompatibility between the mods.

The incompatibility can be resolved by retrieving the master using `inventory.GetComponent<CharacterMaster>()`, which is used by the game.

In this commit, the new method is implemented as a fallback, only used if `body` is null or `body.master` is null.

Thanks to LessFluff#0505 on discord for testing!