### PR TITLE
Add 'NetworkCompatibility' indicating mod isn't needed by other clients

### DIFF
--- a/ShareSuite/ShareSuite.cs
+++ b/ShareSuite/ShareSuite.cs
@@ -14,6 +14,7 @@ namespace ShareSuite
     [BepInDependency("com.bepis.r2api")]
     [BepInPlugin("com.funkfrog_sipondo.sharesuite", "ShareSuite", "2.0.0")]
     [R2APISubmoduleDependency("CommandHelper", "ItemDropAPI")]
+    [NetworkCompatibility(CompatibilityLevel.NoNeedForSync, VersionStrictness.DifferentModVersionsAreOk)]
     public class ShareSuite : BaseUnityPlugin
     {
         #region ConfigWrapper init


### PR DESCRIPTION
## In brief
* Add R2API's `NetworkCompatibility` attribute set to `NoNeedForSync`
  * SharedItems doesn't require all clients to have the mod, just the host
  * SharedItems shouldn't have issues with different mod versions, either, host controls the experience
  * Should remove the need for build ID patching mods

**Note:  I have not yet tested this change.**

## Details
SharedItems should make use of the `NetworkCompatibility` attribute added in [R2API's release for RoR2 v1.0](https://github.com/risk-of-thunder/R2API/blob/master/README.md#changelog).

From what I understand, this may remove the need for a build ID changing mod when the host has all server-only mods installed, which will simplify setting up multiplayer games.  [The upstream pull request on the R2API has much more details](https://github.com/risk-of-thunder/R2API/pull/188 ).

### Alternatives
* Make no changes
  * Build ID changing mods will work as before