### PR TITLE
Item Duplication Fix

### DIFF
--- a/ShareSuite/GeneralHooks.cs
+++ b/ShareSuite/GeneralHooks.cs
@@ -78,7 +78,7 @@ namespace ShareSuite
         public static bool IsMultiplayer()
         {
             // Check whether the quantity of players in the lobby exceeds one.
-            return PlayerCharacterMasterController.instances.Count > 1;
+            return ShareSuite.OverrideMultiplayerCheck.Value || PlayerCharacterMasterController.instances.Count > 1;
         }
 
         private static void InteractibleCreditOverride(On.RoR2.SceneDirector.orig_PlaceTeleporter orig, SceneDirector self)

--- a/ShareSuite/ItemSharingHooks.cs
+++ b/ShareSuite/ItemSharingHooks.cs
@@ -210,9 +210,13 @@ namespace ShareSuite
 
             var costType = self.GetComponent<PurchaseInteraction>().costType;
 
+            //If is valid drop and dupe fix not enabled, true -> we want the item to pop
+            //if is valid drop and dupe fix is enabled, false -> item IS shared, we don't want the item to pop, PrinterCauldronFix should deal with this
+            //if is not valid drop and dupe fix is not enabled, true -> item ISN'T shared, and dupe fix isn't enabled, we want to pop 
+            //if is not valid drop and dupe fix is enabled, false -> item ISN'T shared, dupe fix should catch, we don't want to pop
+
             if (!GeneralHooks.IsMultiplayer() // is not multiplayer
-                || !IsValidItemPickup(self.CurrentPickupIndex()) // item is not shared
-                || !ShareSuite.PrinterCauldronFixEnabled.Value // dupe fix isn't enabled
+                || (!IsValidItemPickup(self.CurrentPickupIndex()) && !ShareSuite.PrinterCauldronFixEnabled.Value) //if it's not a valid drop AND the dupe fix isn't enabled
                 || self.itemTier == ItemTier.Lunar
                 || costType == CostTypeIndex.Money)
             {
@@ -248,6 +252,7 @@ namespace ShareSuite
                 {
                     var item = PickupCatalog.GetPickupDef(shop.CurrentPickupIndex()).itemIndex;
                     inventory.GiveItem(item);
+                    
                     orig(self, activator);
                     ChatHandler.SendRichCauldronMessage(inventory.GetComponent<CharacterMaster>(),
                         shop.CurrentPickupIndex());

--- a/ShareSuite/ShareSuite.cs
+++ b/ShareSuite/ShareSuite.cs
@@ -38,7 +38,8 @@ namespace ShareSuite
             MoneyScalarEnabled,
             RandomizeSharedPickups,
             LunarItemsRandomized,
-            BossItemsRandomized;
+            BossItemsRandomized,
+            OverrideMultiplayerCheck; 
 
         public static ConfigEntry<int> BossLootCredit, VoidFieldLootCredit;
         public static ConfigEntry<double> InteractablesCredit, MoneyScalar;
@@ -236,7 +237,7 @@ namespace ShareSuite
                 "OverrideBossLootScaling",
                 true,
                 "Toggles override of the scalar of boss loot drops to your configured balance."
-            );
+            );      
 
             BossLootCredit = Config.Bind(
                 "Balance",
@@ -250,6 +251,13 @@ namespace ShareSuite
                 "OverrideVoidLootScaling",
                 true,
                 "Toggles override of the scalar of Void Field loot drops to your configured balance."
+            );
+
+            OverrideMultiplayerCheck = Config.Bind(
+                "Debug",
+                "OverrideMultiplayerCheck",
+                false,
+                "Forces ShareSuite to think that the game is running in a multiplayer instance."
             );
 
             VoidFieldLootCredit = Config.Bind(


### PR DESCRIPTION
#104 

Decided to look into this issue before my next session with my friends - It looks like the OnPurchaseDrop hook would do it's original function even if the duplication fix was enabled, due to the IsValidItemPickup check superseding it. 