### PR TITLE
Fix for getting items when a drone.

### DIFF
--- a/ShareSuite/ChatHandler.cs
+++ b/ShareSuite/ChatHandler.cs
@@ -242,7 +242,7 @@ namespace ShareSuite
                 if (!master.hasBody || master.GetBody() == body) continue;
 
                 // If the player is dead/deadplayersgetitems is off, continue and add nothing
-                if (master.IsDeadAndOutOfLivesServer() && !ShareSuite.DeadPlayersGetItems.Value) continue;
+                if (ItemSharingHooks.IsDeadAndNotADrone(master) && !ShareSuite.DeadPlayersGetItems.Value) continue;
 
                 // Get the player color
                 var playerColor = GetPlayerColor(playerCharacterMasterController);
@@ -285,7 +285,7 @@ namespace ShareSuite
                 if (!master.inventory || master.GetBody() == body) continue;
 
                 // If the player is alive, add one to eligablePlayers
-                if (!master.IsDeadAndOutOfLivesServer() || ShareSuite.DeadPlayersGetItems.Value)
+                if (!ItemSharingHooks.IsDeadAndNotADrone(master) || ShareSuite.DeadPlayersGetItems.Value)
                 {
                     eligiblePlayers++;
                 }

--- a/ShareSuite/EquipmentSharingHooks.cs
+++ b/ShareSuite/EquipmentSharingHooks.cs
@@ -66,7 +66,7 @@ namespace ShareSuite
             {
                 CreateDropletIfExists(oldEquipPickupIndex, self.transform.position);
                 return;
-            }
+            }    
             // If the new equip is shared, create a droplet of the old one.
             else if (EquipmentShared(newEquip))
                 CreateDropletIfExists(oldEquipPickupIndex, self.transform.position);
@@ -171,7 +171,7 @@ namespace ShareSuite
         private static int GetLivingPlayersWithEquipment(EquipmentIndex originalEquip)
         {
             return PlayerCharacterMasterController.instances.Select(p => p.master)
-                .Where(p => p.inventory && !p.IsDeadAndOutOfLivesServer())
+                .Where(p => p.inventory && !ItemSharingHooks.IsDeadAndNotADrone(p))
                 .Count(master => master.inventory.currentEquipmentIndex == originalEquip);
         }
 

--- a/ShareSuite/ItemSharingHooks.cs
+++ b/ShareSuite/ItemSharingHooks.cs
@@ -1,15 +1,16 @@
-using System;
+using EntityStates.Scrapper;
+using MonoMod.Cil;
+using R2API.Utils;
+using RewiredConsts;
 using RoR2;
+using ShareSuite.Networking;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using MonoMod.Cil;
-using R2API.Utils;
 using UnityEngine;
 using UnityEngine.Networking;
 using Random = UnityEngine.Random;
-using EntityStates.Scrapper;
-using ShareSuite.Networking;
 
 namespace ShareSuite
 {
@@ -166,7 +167,7 @@ namespace ShareSuite
                              .Select(p => p.master))
                 {
                     // Do not reward dead players if not required
-                    if (!ShareSuite.DeadPlayersGetItems.Value && player.IsDeadAndOutOfLivesServer()) continue;
+                    if (!ShareSuite.DeadPlayersGetItems.Value && IsDeadAndNotADrone(player)) continue;
 
                     // Do not give an additional item to the player who picked it up.
                     if (player.inventory == body.inventory)
@@ -227,6 +228,12 @@ namespace ShareSuite
 
             // ReSharper disable once PossibleNullReferenceException
             HandleRichMessageUnlockAndNotification(master, item.pickupIndex);
+        }
+
+        public static bool IsDeadAndNotADrone(CharacterMaster master)
+        {
+            if (master == null || master.GetBody() == null) return true;
+            return master.IsDeadAndOutOfLivesServer() && !master.GetBody().IsDrone;
         }
 
         private static string FixZeroItemCount(On.RoR2.Chat.PlayerPickupChatMessage.orig_ConstructChatString orig,

--- a/ShareSuite/ShareSuite.cs
+++ b/ShareSuite/ShareSuite.cs
@@ -91,7 +91,7 @@ namespace ShareSuite
 
             foreach (var playerCharacterMasterController in PlayerCharacterMasterController.instances)
             {
-                if (playerCharacterMasterController.master.IsDeadAndOutOfLivesServer()) continue;
+                if (ItemSharingHooks.IsDeadAndNotADrone(playerCharacterMasterController.master)) continue;
                 if (playerCharacterMasterController.master.money == MoneySharingHooks.SharedMoneyValue) continue;
                 playerCharacterMasterController.master.money = (uint) MoneySharingHooks.SharedMoneyValue;
             }


### PR DESCRIPTION
**Intended behaviour:**
When dead with deadplayersgetitems FALSE -> No item shared to dead player
When dead with deadplayersgetitems TRUE -> Item shared to dead player
When drone with deadplayersgetitems FALSE -> Item shared to dead player
When drone with deadplayersgetitems TRUE -> Item shared to dead player