### PR TITLE
Temporary items sharing configuration

### DIFF
--- a/ShareSuite/ChatHandler.cs
+++ b/ShareSuite/ChatHandler.cs
@@ -98,13 +98,26 @@ namespace ShareSuite
 
             if (temporary)
             {
-                var singlePickupMessage =
-                    $"<color=#{playerColor}>{body.GetUserName()}</color> <color=#{GrayColor}>picked up</color> " +
-                    $"<color=#{ColorUtility.ToHtmlStringRGB(pickupColor)}>" +
-                    $"{(string.IsNullOrEmpty(pickupName) ? "???" : pickupName)} ({itemCount})</color> <color=#{GrayColor}>for themselves. </color>" +
-                    $"<color=#{NotSharingColor}>(Item is temporary, so not shared)</color>";
-                Chat.SendBroadcastChat(new Chat.SimpleChatMessage { baseToken = singlePickupMessage });
-                return;
+                if (ShareSuite.TemporaryItemsShared.Value)
+                {
+                    var tempPickupMessage =
+                        $"<color=#{playerColor}>{body.GetUserName()}</color> <color=#{GrayColor}>picked up temporary</color> " +
+                        $"<color=#{ColorUtility.ToHtmlStringRGB(pickupColor)}>" +
+                        $"{(string.IsNullOrEmpty(pickupName) ? "???" : pickupName)} ({itemCount})</color> <color=#{GrayColor}>for everyone</color>" +
+                        $"{ItemPickupFormatter(body)}<color=#{GrayColor}>.</color>";
+                    Chat.SendBroadcastChat(new Chat.SimpleChatMessage { baseToken = tempPickupMessage });
+                    return;
+                }
+                else
+                {
+                    var singlePickupMessage =
+                        $"<color=#{playerColor}>{body.GetUserName()}</color> <color=#{GrayColor}>picked up</color> " +
+                        $"<color=#{ColorUtility.ToHtmlStringRGB(pickupColor)}>" +
+                        $"{(string.IsNullOrEmpty(pickupName) ? "???" : pickupName)} ({itemCount})</color> <color=#{GrayColor}>for themselves. </color>" +
+                        $"<color=#{NotSharingColor}>(Item is temporary, so not shared)</color>";
+                    Chat.SendBroadcastChat(new Chat.SimpleChatMessage { baseToken = singlePickupMessage });
+                    return;
+                }
             }
 
             if (Blacklist.HasItem(pickupDef.itemIndex) || !ItemSharingHooks.IsValidItemPickup(pickupDef.pickupIndex))

--- a/ShareSuite/Properties/launchSettings.json
+++ b/ShareSuite/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "ShareSuite": {
+      "commandName": "Project"
+    },
+    "RoR2 Mod Launch": {
+      "commandName": "Executable",
+      "executablePath": "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Risk of Rain 2\\Risk of Rain 2.exe",
+      "commandLineArgs": "--doorstop-enabled true --doorstop-target-assembly \"%appdata%\\r2modmanPlus-local\\RiskOfRain2\\profiles\\Default\\BepInEx\\core\\BepInEx.Preloader.dll\""
+    }
+  }
+}

--- a/ShareSuite/ShareSuite.cs
+++ b/ShareSuite/ShareSuite.cs
@@ -633,6 +633,27 @@ namespace ShareSuite
             }
         }
 
+        // TemporaryItemsShared
+        [ConCommand(commandName = "ss_TemporaryItemsShared", flags = ConVarFlags.None,
+            helpText = "Modifies whether temporary items are shared or not.")]
+        private static void CcTemporaryItemsShared(ConCommandArgs args)
+        {
+            if (args.Count == 0)
+            {
+                Debug.Log(TemporaryItemsShared.Value);
+                return;
+            }
+
+            var valid = TryGetBool(args[0]);
+            if (!valid.HasValue)
+                Debug.Log("Couldn't parse to boolean.");
+            else
+            {
+                TemporaryItemsShared.Value = valid.Value;
+                Debug.Log($"Temporary item sharing set to {TemporaryItemsShared.Value}.");
+            }
+        }
+
         // RichMessagesEnabled
         [ConCommand(commandName = "ss_RichMessagesEnabled", flags = ConVarFlags.None,
             helpText = "Modifies whether rich messages are enabled or not.")]

--- a/ShareSuite/ShareSuite.cs
+++ b/ShareSuite/ShareSuite.cs
@@ -53,6 +53,7 @@ namespace ShareSuite
             LunarItemsShared,
             BossItemsShared,
             VoidItemsShared,
+            TemporaryItemsShared,
             RichMessagesEnabled,
             DropBlacklistedEquipmentOnShare,
             PrinterCauldronFixEnabled,
@@ -188,6 +189,13 @@ namespace ShareSuite
                 "VoidItemsShared",
                 false,
                 "Toggles item sharing for void (purple/corrupted) items."
+            );
+
+            TemporaryItemsShared = Config.Bind(
+                "Settings",
+                "TemporaryItemsShared",
+                false,
+                "Toggles item sharing for temporary items."
             );
 
             RichMessagesEnabled = Config.Bind(

--- a/ShareSuite/ShareSuite.csproj.user
+++ b/ShareSuite/ShareSuite.csproj.user
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DebuggerFlavor>ProjectDebugger</DebuggerFlavor>
+  </PropertyGroup>
+  <PropertyGroup>
+    <ActiveDebugProfile>RoR2 Mod Launch</ActiveDebugProfile>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Added the possiblity to share temporary items. Default is false due to Drifter becomming very overpowered.
In addition it contains a lazy setting for developers, press F5 to launch the game (with mods).
Resolved #237.